### PR TITLE
修复jrrp插件的部分问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@ const { Schema: S } = require('koishi')
 const core = require('./src/core.js')
 
 module.exports.name = 'jrrp'
+module.exports.inject = {
+    optional: ['database'],
+}
 
 const ToString = S.union([
   S.string(),

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "koishi": {
     "description": {
       "zh": "今日人品插件"
+    },
+    "service": {
+        "optional": ["database"]
     }
   },
   "peerDependencies": {

--- a/src/core.js
+++ b/src/core.js
@@ -59,7 +59,7 @@ module.exports = (ctx, config) => {
 
       const luck = createHash('sha256')
       luck.update(session.userId)
-      luck.update((new Date().getTime() / (1000 * 60 * 60 * 24)).toFixed(0))
+      luck.update(`${~~((Date.now()-new Date().getTimezoneOffset()*6e4)/864e5)}`)
       luck.update('42')
 
       const luckValue = parseInt(luck.digest('hex'), 16) % 101

--- a/src/core.js
+++ b/src/core.js
@@ -54,6 +54,7 @@ module.exports = (ctx, config) => {
       /** @type {string} */
       let name
       if (ctx.database) name = session.user.name
+      if (!name) name = session.author.nick
       if (!name) name = session.author.nickname
       if (!name) name = session.author.username
 


### PR DESCRIPTION
1. 根据服务器的时区来更新今日人品值。 #3 
2. 修复插件运行时出现的`property database is not registered`错误。 #2 
3. 修复在QQ群场景使用本插件时，显示用户昵称而不是群名片的问题。